### PR TITLE
Fix branch protection script to auto-detect repo

### DIFF
--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -19,11 +19,20 @@ if ! gh auth status &> /dev/null; then
     exit 1
 fi
 
+# Determine repository slug (owner/repo)
+REPO=${GITHUB_REPOSITORY:-$(git config --get remote.origin.url | \
+  sed -n 's#.*github.com[:/]\(.*\)\.git#\1#p')}
+
+if [ -z "$REPO" ]; then
+    echo "Unable to determine repository. Set GITHUB_REPOSITORY environment variable."
+    exit 1
+fi
+
 # Set up branch protection rules using JSON input
 gh api \
   --method PUT \
   -H "Accept: application/vnd.github.v3+json" \
-  /repos/brendendurham/mushinai-enterprise-ai/branches/main/protection \
+  /repos/${REPO}/branches/main/protection \
   --input - <<EOF
 {
   "required_status_checks": {


### PR DESCRIPTION
## Summary
- improve `setup-branch-protection.sh` so it detects the repository from `git`
- use detected repo in the `gh api` call

## Testing
- `make test` *(fails: pytest: error: unrecognized arguments)*
- `npm test` *(fails: ENOENT: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843af4634108333a2fbb8fe050c5a8c