### PR TITLE
feat(docs): add parallel issue setup

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,0 +1,26 @@
+# Parallel Issue Setup
+
+This directory contains a CSV file describing a set of issues that can be created in parallel using the GitHub API.
+
+## Files
+
+- `parallel_issues.csv` - CSV with columns `title`, `body`, and optional `labels`.
+- `../../scripts/bulk_create_issues.py` - Script to create issues concurrently.
+
+## Usage
+
+1. Ensure you have Python 3.8+ and install dependencies:
+   ```bash
+   pip install aiohttp
+   ```
+2. Export your GitHub repository and token:
+   ```bash
+   export GITHUB_REPOSITORY="owner/repo"
+   export GITHUB_TOKEN="<YOUR_PERSONAL_ACCESS_TOKEN>"
+   ```
+3. Run the script with the CSV file:
+   ```bash
+   python scripts/bulk_create_issues.py docs/tasks/parallel_issues.csv
+   ```
+
+The script will create each issue concurrently, printing the created issue numbers upon success.

--- a/docs/tasks/parallel_issues.csv
+++ b/docs/tasks/parallel_issues.csv
@@ -1,0 +1,11 @@
+id,title,body,labels
+1,Setup REST API skeleton,Create the basic FastAPI skeleton under api/rest/v1,backend
+2,Implement authentication service,Add JWT-based authentication with user roles,backend
+3,Configure GraphQL API,Build initial GraphQL schema and resolver layout,backend
+4,Add Salesforce integration,Create integration module to sync data with Salesforce,integrations
+5,Implement Kubernetes deployment,Setup Helm charts and deployment pipelines,infra
+6,Implement user dashboard frontend,Create React dashboard for user analytics,frontend
+7,Create billing service,Build microservice for subscription management,backend
+8,Set up CI/CD with GitHub Actions,Automate tests and deployment pipelines,devops
+9,Write unit tests for core modules,Increase test coverage to 80%,testing
+10,Add logging and monitoring stack,Integrate Prometheus and Grafana for monitoring,infra

--- a/scripts/bulk_create_issues.py
+++ b/scripts/bulk_create_issues.py
@@ -1,0 +1,44 @@
+import csv
+import os
+import asyncio
+import aiohttp
+
+GITHUB_API = "https://api.github.com"
+REPO = os.environ.get("GITHUB_REPOSITORY")  # e.g., 'owner/repo'
+TOKEN = os.environ.get("GITHUB_TOKEN")
+
+if not REPO:
+    raise EnvironmentError("GITHUB_REPOSITORY not set")
+if not TOKEN:
+    raise EnvironmentError("GITHUB_TOKEN not set")
+
+HEADERS = {
+    "Authorization": f"Bearer {TOKEN}",
+    "Accept": "application/vnd.github+json",
+}
+
+async def create_issue(session, title, body, labels):
+    url = f"{GITHUB_API}/repos/{REPO}/issues"
+    payload = {"title": title, "body": body, "labels": labels.split(',') if labels else []}
+    async with session.post(url, json=payload, headers=HEADERS) as resp:
+        if resp.status != 201:
+            text = await resp.text()
+            raise RuntimeError(f"Failed to create issue {title}: {resp.status} {text}")
+        data = await resp.json()
+        print(f"Created issue #{data['number']}: {title}")
+
+async def main(csv_path):
+    async with aiohttp.ClientSession() as session:
+        tasks = []
+        with open(csv_path, newline='') as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                tasks.append(create_issue(session, row['title'], row['body'], row.get('labels', '')))
+        await asyncio.gather(*tasks)
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Bulk create GitHub issues in parallel.")
+    parser.add_argument('csv', help='CSV file with columns: title, body, labels')
+    args = parser.parse_args()
+    asyncio.run(main(args.csv))


### PR DESCRIPTION
## Summary
- provide `scripts/bulk_create_issues.py` to create GitHub issues concurrently
- add issue list CSV and usage docs in `docs/tasks`

## Testing
- `make test` *(fails: unrecognized arguments in pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68512bda92bc8333ab2f660b4d1f85a2